### PR TITLE
Leave in _id and __v on lean queries

### DIFF
--- a/utils/__tests__/baseSchemaPlugin.test.js
+++ b/utils/__tests__/baseSchemaPlugin.test.js
@@ -80,11 +80,13 @@ test('Correct document references should be allowed', async (t) => {
 test('Virtuals should be returned on lean queries', async (t) => {
   const person = await Person.create({ name: 'findable' });
   const expectedOutput = {
+    _id: person.id,
     id: person.id,
     name: person.name,
     createdAt: person.createdAt,
     updatedAt: person.updatedAt,
     virtual_prop: 'some value',
+    __v: 0,
   };
 
   t.deepEqual(
@@ -104,47 +106,20 @@ test('Virtuals should work in the select statement', async (t) => {
 
   t.deepEqual(
     await Person.find({ name: 'hunt' }, 'virtual_prop').lean().exec(),
-    [{ virtual_prop: 'some value' }],
+    [{ _id: person.id, virtual_prop: 'some value' }],
     'Wrong fields for just a virtual selection',
   );
 
   t.deepEqual(
     await Person.find({ name: 'hunt' }, 'name virtual_prop').lean().exec(),
-    [{ name: 'hunt', virtual_prop: 'some value' }],
+    [{ _id: person.id, name: 'hunt', virtual_prop: 'some value' }],
     'Wrong fields for a real and virtual selection',
   );
 
   t.deepEqual(
     await Person.find({ name: 'hunt' }, 'id name').lean().exec(),
-    [{ id: person.id, name: 'hunt' }],
+    [{ _id: person.id, id: person.id, name: 'hunt' }],
     'Wrong fields for a real and `id` selection',
-  );
-});
-
-test('_id and __v should be removed in lean queries', async (t) => {
-  const person = await Person.create({ name: 'fishing' });
-  const expectedOutput = {
-    name: person.name,
-    createdAt: person.createdAt,
-    updatedAt: person.updatedAt,
-  };
-
-  t.deepEqual(
-    await Person.find({ name: 'fishing' }).lean().exec(),
-    [expectedOutput],
-    'Atrifacts remain when alling `Query.find`',
-  );
-
-  t.deepEqual(
-    await Person.findOne({ name: 'fishing' }).lean().exec(),
-    expectedOutput,
-    'Artifacts remain when calling `Query.findOne`',
-  );
-
-  t.deepEqual(
-    await Person.findOneAndUpdate({ name: 'fishing' }, {}).lean().exec(),
-    expectedOutput,
-    'Artifacts remain when calling `Query.findOneAndUpdate`',
   );
 });
 

--- a/utils/baseSchemaPlugin.js
+++ b/utils/baseSchemaPlugin.js
@@ -26,21 +26,4 @@ module.exports = (schema) => {
   schema.plugin(leanVirtuals);
   schema.plugin(selectVirtuals);
   schema.plugin(beautifyUnique);
-
-  // We want to strip out `_id` and `__v` from lean qeries, just like we do with `toJSON` and
-  // `toObject`.
-  function stripDocumentArtifacts(res) {
-    if (!this._mongooseOptions.lean) return;
-
-    const docs = Array.isArray(res) ? res : [res];
-
-    docs.forEach((doc) => {
-      delete doc._id; // eslint-disable-line no-param-reassign
-      delete doc.__v; // eslint-disable-line no-param-reassign
-    });
-  }
-
-  schema.post('find', stripDocumentArtifacts);
-  schema.post('findOne', stripDocumentArtifacts);
-  schema.post('findOneAndUpdate', stripDocumentArtifacts);
 };


### PR DESCRIPTION
The code before was trying to strip out these unneeded fields from lean queries so they wouldn't be seen on the client. The problem was that the code was stripping _id while mongoose was still trying to use it to insert populated fields. So population broke. I considered a few ways of stripping the fields and then decided that it's not worth it at this point and it's fine to send them to the client :P