### PR TITLE
Setting Up JWT Handling (and so slight organization)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@
 MONGODB_URI=
 NODE_ENV=
 DEBUG=
+JWT_SECRET={secret}

--- a/middleware/devTokenHandler.js
+++ b/middleware/devTokenHandler.js
@@ -1,0 +1,15 @@
+/**
+ * For development, loads a plain text auth token from the query params.
+ * This makes experimenting with the API faster from a browser
+ */
+module.exports = (req, res, next) => {
+  if (
+    process.env.NODE_ENV === 'development'
+    && req.query.token
+    && !req.user
+  ) {
+    req.user = JSON.parse(req.query.token);
+  }
+
+  next();
+};

--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -1,0 +1,22 @@
+const _ = require('lodash');
+const debug = require('debug')('majorkey2api');
+
+module.exports = (err, req, res, next) => { // eslint-disable-line no-unused-vars
+  debug(err);
+
+  const status = _.get(req, 'erm.statusCode', 400);
+  let errorToShow = { message: err.message };
+
+  if (err.name === 'ValidationError') {
+    // Send back details to the client so they can intelligently tell the user what's up
+    errorToShow = {
+      message: err._message, // eslint-disable-line no-underscore-dangle
+      name: err.name,
+      errors: _.mapValues(err.errors, 'message'),
+    };
+  }
+
+  res.setHeader('Content-Type', 'application/json');
+  res.status(status).json(errorToShow);
+};
+

--- a/middleware/notFound.js
+++ b/middleware/notFound.js
@@ -1,0 +1,5 @@
+const http = require('http');
+
+module.exports = (req, res) => {
+  res.status(404).json({ message: http.STATUS_CODES[404] });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1391,6 +1391,11 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -2544,6 +2549,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3211,6 +3224,24 @@
         "lodash.assign": "^3.2.0"
       }
     },
+    "express-jwt": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.1.tgz",
+      "integrity": "sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==",
+      "requires": {
+        "async": "^1.5.0",
+        "express-unless": "^0.3.0",
+        "jsonwebtoken": "^8.1.0",
+        "lodash.set": "^4.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
     "express-restify-mongoose": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/express-restify-mongoose/-/express-restify-mongoose-5.0.0.tgz",
@@ -3228,6 +3259,11 @@
         "serialize-error": "~2.1.0",
         "weedout": "~1.0.1"
       }
+    },
+    "express-unless": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
+      "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
     },
     "ext-list": {
       "version": "2.2.2",
@@ -5522,6 +5558,29 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
+      "requires": {
+        "jws": "^3.1.5",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5532,6 +5591,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kareem": {
@@ -5750,6 +5828,11 @@
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
       "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -5760,10 +5843,30 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -5791,6 +5894,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -5830,6 +5938,11 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.some": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "engine-strict": "1.0.0",
     "express": "4.16.3",
     "express-force-ssl": "0.3.2",
+    "express-jwt": "5.3.1",
     "express-restify-mongoose": "5.0.0",
     "feathers-mongoose": "6.1.2",
     "helmet": "3.12.1",

--- a/utils/envVerification.js
+++ b/utils/envVerification.js
@@ -8,6 +8,7 @@ module.exports = {
       MONGODB_URI: Joi.string().uri().required(),
       NODE_ENV: Joi.valid('production', 'development', 'test').required(),
       DEBUG: Joi.string(),
+      JWT_SECRET: Joi.string().required(),
     };
 
     const result = Joi.validate(


### PR DESCRIPTION
Implement the jwt handling in much the same way as Gio's diff. Also provides a plain text way to specify the content of the JWT via query param to make development easier. This is only available in development.

Hit `/api/v1/user?token={"id":"[someUserId]"}`

@ericgio Note that when doing API requests from the URL bar in dev, you'll need to pass a token in as the query param and it'll skip looking for a signed JWT. Let me know if you run into any issues. I need to land this to work on some related changes.

This is actually cherry picking the first rev from the #38 