### PR TITLE
Easier specification of the dev Token

### DIFF
--- a/middleware/devTokenHandler.js
+++ b/middleware/devTokenHandler.js
@@ -8,7 +8,7 @@ module.exports = (req, res, next) => {
     && req.query.token
     && !req.user
   ) {
-    req.user = JSON.parse(req.query.token);
+    req.user = req.query.token;
 
     // remove the query param so nothing downstream applies it to the query
     delete req.query.token;


### PR DESCRIPTION
I read up on how express parses the query params. Instead of doing `token={"user":"someId"}` you can now just do `token[user]=someId`. Much better, and less code!