### PR TITLE
 Allow tokens with email addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const errorHandler = require('./middleware/errorHandler');
 const notFound = require('./middleware/notFound');
 const devTokenHandler = require('./middleware/devTokenHandler');
 const loadMemberships = require('./middleware/loadMemberships');
+const emailToUserId = require('./middleware/emailToUserId');
 
 const v1Router = require('./v1');
 const v2Router = require('./v2');
@@ -29,6 +30,7 @@ app.use(
   compression(),
   devTokenHandler,
   jwt({ secret: process.env.JWT_SECRET }).unless(req => !!req.user),
+  emailToUserId,
   loadMemberships,
   v1Router,
   v2Router,

--- a/middleware/emailToUserId.js
+++ b/middleware/emailToUserId.js
@@ -12,8 +12,14 @@ module.exports = async function emailToUserId(req, res, next) {
   const { user: { id, email } } = req;
   if (id || !email) return next();
 
-  const { _id: userId } = await User.findOne({ email }, '_id').exec();
-  _.set(req, 'user.id', userId);
+  const user = await User
+    .findOne({ email }, '_id')
+    .setAuthLevel(false)
+    .exec();
+
+  if (user && user._id) {
+    _.set(req, 'user.id', user._id);
+  }
 
   return next();
 };

--- a/middleware/emailToUserId.js
+++ b/middleware/emailToUserId.js
@@ -1,0 +1,19 @@
+const _ = require('lodash');
+const User = require('../userModel');
+
+/**
+ * Just after authenticating, clients may only have verified the user's
+ * email address and don't yet have their id. This allows them to create
+ * a token that contain the email address and this middleware will look up
+ * the email address and add the correct id to `req.user` so further downstream
+ * authz checks will work.
+ */
+module.exports = async function emailToUserId(req, res, next) {
+  const { user: { id, email } } = req;
+  if (id || !email) return next();
+
+  const { _id: userId } = await User.findOne({ email }, '_id').exec();
+  _.set(req, 'user.id', userId);
+
+  return next();
+};


### PR DESCRIPTION
Just after authenticating, clients may only have verified the user's
email address and don't yet have their id. This allows them to create
a token that contain the email address and this middleware will look up
the email address and add the correct id to `req.user` so further downstream
authz checks will work.